### PR TITLE
fix: tidy utils

### DIFF
--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -169,3 +169,4 @@ if (!fs.existsSync(CONFIG_FILE)) {
 }
 
 export default config;
+

--- a/src/utils/cache.ts
+++ b/src/utils/cache.ts
@@ -336,3 +336,4 @@ export class CacheService<T = any> {
 
 // Export singleton instance
 export const cacheService = new CacheService();
+

--- a/src/utils/cacheWrapper.ts
+++ b/src/utils/cacheWrapper.ts
@@ -25,8 +25,8 @@ export function refreshCacheConfig(): void {
 export function withCache<T extends (...args: any[]) => any>(
   fn: T,
   keyGenerator?: (...args: Parameters<T>) => string
-): (...args: Parameters<T>) => Promise<ReturnType<T>> {
-  return async (...args: Parameters<T>): Promise<ReturnType<T>> => {
+): (...args: Parameters<T>) => Promise<Awaited<ReturnType<T>>> {
+  return async (...args: Parameters<T>): Promise<Awaited<ReturnType<T>>> => {
     if (!config.get<Config['cache']['enabled']>('cache.enabled')) {
       return fn(...args);
     }

--- a/src/utils/cacheWrapper.ts
+++ b/src/utils/cacheWrapper.ts
@@ -1,5 +1,6 @@
 import { cacheService, CacheService } from './cache';
 import { config } from '../config';
+import type { Config } from '../config';
 import { logger } from './logger';
 
 // Initialize cache with config
@@ -24,7 +25,7 @@ export function refreshCacheConfig(): void {
 export function withCache<T extends (...args: any[]) => any>(
   fn: T,
   keyGenerator?: (...args: Parameters<T>) => string
-): (...args: Parameters<T>) => ReturnType<T> {
+): (...args: Parameters<T>) => Promise<ReturnType<T>> {
   return async (...args: Parameters<T>): Promise<ReturnType<T>> => {
     if (!config.get<Config['cache']['enabled']>('cache.enabled')) {
       return fn(...args);

--- a/src/utils/commandExecutor.ts
+++ b/src/utils/commandExecutor.ts
@@ -155,3 +155,4 @@ export function invalidateCommandCache(command: string, args: string[] = []): vo
 export function clearCommandCache(): void {
   cacheService.clear();
 }
+

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { execa, ExecaChildProcess } from 'execa';
+import { execa } from 'execa';
 import chalk from 'chalk';
 import { TextProps } from 'ink';
 import { logger, handleError } from './logger';
@@ -278,11 +278,14 @@ export const formatText = (text: string, props: TextProps = {}): string => {
  * Create a loading spinner
  */
 export const createSpinner = (text: string, spinnerType = 'dots'): Spinner => {
+  const framesMap: Record<string, string[]> = {
+    dots: ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'],
+    line: ['-', '\\', '|', '/'],
+  };
+
   const spinner = {
     interval: 80,
-    frames: [
-      '⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'
-    ],
+    frames: framesMap[spinnerType] || framesMap.dots,
     text: '',
     start(text: string) {
       this.text = text;
@@ -291,6 +294,13 @@ export const createSpinner = (text: string, spinnerType = 'dots'): Spinner => {
     },
     stop() {
       process.stdout.write('\r' + ' '.repeat(process.stdout.columns || 80) + '\r');
+      return this;
+    },
+    stopAndPersist(options?: { symbol?: string; text?: string }) {
+      this.stop();
+      const symbol = options?.symbol ?? ' ';
+      const text = options?.text ?? this.text;
+      console.log(`${symbol} ${text}`);
       return this;
     },
     succeed(text?: string) {
@@ -316,13 +326,13 @@ export const createSpinner = (text: string, spinnerType = 'dots'): Spinner => {
     render(frame: number) {
       const frameIndex = frame % this.frames.length;
       process.stdout.write(
-        '\r' + 
-        chalk.blue(this.frames[frameIndex]) + 
-        ' ' + 
+        '\r' +
+        chalk.blue(this.frames[frameIndex]) +
+        ' ' +
         this.text
       );
     },
   };
-  
+
   return spinner.start(text);
 };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -6,3 +6,4 @@ export * from './cache';
 export * from './cacheWrapper';
 export * from './commandExecutor';
 // Export other utility files here as we create them
+

--- a/src/utils/logRotationService.ts
+++ b/src/utils/logRotationService.ts
@@ -1,7 +1,5 @@
 import fs from 'fs-extra';
-import path from 'path';
 import { LoggerConfig as ExternalLoggerConfig } from '../config/loggerConfig'; // Assuming this is the main config
-import { logger as mainLogger } from './logger'; // For internal logging of rotation issues
 
 type RotationConfig = Pick<ExternalLoggerConfig, 'logFilePath' | 'maxLogFileSize' | 'maxLogFiles' | 'fileOutput'>;
 


### PR DESCRIPTION
## Summary
- refine helper spinner to support multiple frame styles and persistent output
- correct cache wrapper typing and import Config
- streamline log rotation service imports and tidy file endings

## Testing
- `npm run lint` *(fails: Cannot read config file: module is not defined)*
- `npm test` *(fails: 22 failed | 3 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6891509c86bc83278b9b83c0e85c96b2